### PR TITLE
feat(reddit): helper functions for reposting

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 backports.functools-lru-cache==1.4
+beautifulsoup4==4.7.1
 certifi==2017.4.17
 chardet==3.0.4
 cobe==2.1.2

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 import time
 import random
 import os
+from collections import namedtuple
 from os.path import expanduser
 from logger import log
 
@@ -9,6 +10,13 @@ HOME_DIR = expanduser("~")
 DB_DIR = "/reddit-karma-bot/brains"
 MAIN_DB = DB_DIR + "/brain.db"
 SCORE_THRESHOLD = -2
+SUBMISSION_SEARCH_TEMPLATE = \
+    "https://api.pushshift.io/reddit/submission/search/" \
+    "?after={after}&before={before}" \
+    "&sort_type=score&sort=desc" \
+    "&subreddit={subreddit}"
+
+subreddit = namedtuple("Subreddit", ["name", "rank", "url", "subscribers", "type"])
 
 
 def bytesto(bytes, to, bsize=1024):
@@ -27,12 +35,13 @@ def bytesto(bytes, to, bsize=1024):
   return(r)
 
 
-def countdown (seconds):
+def countdown(seconds):
   log.info('sleeping: ' + str(seconds) + " seconds")
   for i in xrange(seconds,0,-1):
       print('\x1b[2K\r' + str(i)+' ')
       time.sleep(1)
   log.info('waking up')
+
 
 def prob(probability):
     rando = random.random() 


### PR DESCRIPTION
- `_pushshift_search`
- `get_submissions`
- `get_top_subreddits`

With these functions we can 'simulate' the no longer available Reddit API time range query.

```python
# example usage in a file 'try.py'
# note that I use 'arrow' for the date things here (pip install arrow)

import arrow
from reddit import get_top_subreddits, get_submissions, 

if __name__ == "__main__":
    MIN_SCORE = 30000
    START_DATE = arrow.get(2019, 1, 1)  # change me
    END_DATE = arrow.get(2019, 4, 1)  # change me
    DATE_DIFF = END_DATE - START_DATE
    subreddits = get_top_subreddits()
    for sub in subreddits[:5]:
        print("\n{}".format("#" * 20))
        print(sub)
        tops = get_submissions(START_DATE.timestamp, END_DATE.timestamp, sub.name)
        big_upvote_posts = list(filter(lambda item: item["score"] >= MIN_SCORE, tops))
        print(
            "found {} posts with score >= {} | time range {}".format(
                len(big_upvote_posts), MIN_SCORE, DATE_DIFF
            )
        )
        time.sleep(1)
```

