### PR TITLE
avoid deleted posts

### DIFF
--- a/src/apis/pushshift.py
+++ b/src/apis/pushshift.py
@@ -35,6 +35,5 @@ class PS():
       response = requests.get(url).json().get("data", [])
       return response
     except Exception as e:
-      print(e)
       # unable to get data from pushshift
       return None

--- a/src/apis/pushshift.py
+++ b/src/apis/pushshift.py
@@ -24,15 +24,17 @@ class PS():
     before=(cur_time - (YEAR - DAY)) if before is None else None
     score = 5000 if score is None else None
     url = f"https://api.pushshift.io/reddit/search/submission/?subreddit={subreddit}"
-    url = (url + f"&before={before}") if before else ""
-    url = (url + f"&after={after}") if after else ""
-    url = (url + f"&score>={score}") if score else ""
-    url = (url + f"&limit={limit}") if limit else ""
+    url = url + (f"&before={before}" if before else "")
+    url = url + (f"&after={after}" if after else "")
+    url = url + (f"&score>={score}" if score else "")
+    url = url + (f"&limit={limit}" if limit else "")
+    url = url + (f"&author!=[deleted]&selftext:not=[deleted]") # avoids deleted posts
     log.info(f"pushshift-url: {url}")
 
     try:
       response = requests.get(url).json().get("data", [])
       return response
     except Exception as e:
+      print(e)
       # unable to get data from pushshift
       return None


### PR DESCRIPTION
+ pushshift api will no longer return deleted or removed posts > which does not mean that there's a 0 chance for a deleted post to be about to get posted through; as the post might've been deleted on reddit thread from which the bot scrapes the thread again instead of directly taking the data from the pushshift api call; so I just added the additional filter in post_actions.py
+ fixed logical bug with the brackets