### PR TITLE
Fixed a bug which occures due to unwanted whitespaces

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -13,6 +13,6 @@ if __name__ == "__main__":
         except KeyboardInterrupt:
             # quit
             sys.exit()
-        else:
-            log.info('Please check your internet connection')
-            sys.exit()
+    else:
+        log.info('Please check your internet connection')
+        sys.exit()


### PR DESCRIPTION
Due to the extra white spaces which were there, the ELSE block won't ever get executed because TRY block would run indefinitely except of a keyboard press when the EXCEPT block would execute.
In the form, it was before the ELSE block would be executed if the TRY block which runs indefinitely finishes executing.