### PR TITLE
Prevent log spam by breaking the loop when running out of comments

### DIFF
--- a/src/bots/reddit/actions/comments/sources/cobe.py
+++ b/src/bots/reddit/actions/comments/sources/cobe.py
@@ -56,6 +56,7 @@ class Cobe():
           comment = next(comments)
         except StopIteration as e:
           log.info(f"end of comments")
+          break
         
         # bot responses are better when it learns from short comments
         if len(comment.body) < 240:


### PR DESCRIPTION
### As it is:
It will run till finished, even if no comments are left.
### With changes:
The loop will break if the end of comments is reached to prevent the spam of logs.